### PR TITLE
Test that `$anchor` applies to the nearest schema identifier only

### DIFF
--- a/tests/json-schema-draft-2019-09/multiple-lookup-external-absolute-uri-with-different-id-anchor.json
+++ b/tests/json-schema-draft-2019-09/multiple-lookup-external-absolute-uri-with-different-id-anchor.json
@@ -37,6 +37,10 @@
         "ref": "http://example.org/foo#baz",
         "target": { "$anchor": "baz", "quux": "eggs" }
       }
+    },
+    {
+      "ref": "http://example.com/#baz",
+      "error": true
     }
   ]
 }

--- a/tests/json-schema-draft-2020-12/multiple-lookup-external-absolute-uri-with-different-id-anchor.json
+++ b/tests/json-schema-draft-2020-12/multiple-lookup-external-absolute-uri-with-different-id-anchor.json
@@ -37,6 +37,10 @@
         "ref": "http://example.org/foo#baz",
         "target": { "$anchor": "baz", "quux": "eggs" }
       }
+    },
+    {
+      "ref": "http://example.com/#baz",
+      "error": true
     }
   ]
 }


### PR DESCRIPTION
The Core specification states the following:

> The base URI to which the resulting fragment is appended is the
> canonical URI of the schema resource containing the "$anchor" or
> "$dynamicAnchor" in question. As discussed in the previous section, this
> is either the nearest "$id" in the same or parent schema object, or the
> base URI for the document as determined according to RFC 3986.

See: https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.2