### PR TITLE
Do not make use of `definitions` in Draft 3 test

### DIFF
--- a/tests/json-schema-draft-03/keywords-additionalItems-boolean.json
+++ b/tests/json-schema-draft-03/keywords-additionalItems-boolean.json
@@ -3,7 +3,7 @@
   "registry": {
     "http://example.com/": {
       "additionalItems": false,
-      "definitions": {
+      "properties": {
         "foo": { "id": "urn:example:foo" }
       }
     }

--- a/tests/json-schema-draft-03/keywords-additionalProperties-boolean.json
+++ b/tests/json-schema-draft-03/keywords-additionalProperties-boolean.json
@@ -3,7 +3,7 @@
   "registry": {
     "http://example.com/": {
       "additionalProperties": false,
-      "definitions": {
+      "properties": {
         "foo": { "id": "urn:example:foo" }
       }
     }

--- a/tests/json-schema-draft-03/pointer-crossing-id-in-dependencies-object.json
+++ b/tests/json-schema-draft-03/pointer-crossing-id-in-dependencies-object.json
@@ -5,7 +5,7 @@
       "dependencies": {
         "foo": {
           "id": "http://example.com/oh-hey-a-subschema",
-          "definitions": {
+          "properties": {
             "id": {},
             "foo": {
               "id": "foo",
@@ -18,7 +18,7 @@
   },
   "tests": [
     {
-      "ref": "http://example.com/#/dependencies/foo/definitions/foo",
+      "ref": "http://example.com/#/dependencies/foo/properties/foo",
       "target": { "id": "foo", "bar": "baz" },
       "then": {
         "ref": "#",

--- a/tests/json-schema-draft-03/pointer-crossing-id-in-items-array.json
+++ b/tests/json-schema-draft-03/pointer-crossing-id-in-items-array.json
@@ -5,7 +5,7 @@
       "items": [
         {
           "id": "http://example.com/oh-hey-an-items",
-          "definitions": {
+          "properties": {
             "id": {},
             "foo": {
               "id": "foo",
@@ -18,7 +18,7 @@
   },
   "tests": [
     {
-      "ref": "http://example.com/#/items/0/definitions/foo",
+      "ref": "http://example.com/#/items/0/properties/foo",
       "target": { "id": "foo", "bar": "baz" },
       "then": {
         "ref": "#",

--- a/tests/json-schema-draft-03/pointer-crossing-id-in-items-object.json
+++ b/tests/json-schema-draft-03/pointer-crossing-id-in-items-object.json
@@ -4,7 +4,7 @@
     "http://example.com/": {
       "items": {
         "id": "http://example.com/oh-hey-an-items",
-        "definitions": {
+        "properties": {
           "id": {},
           "foo": {
             "id": "foo",
@@ -16,7 +16,7 @@
   },
   "tests": [
     {
-      "ref": "http://example.com/#/items/definitions/foo",
+      "ref": "http://example.com/#/items/properties/foo",
       "target": { "id": "foo", "bar": "baz" },
       "then": {
         "ref": "#",


### PR DESCRIPTION
The `definitions` locator keyword was introduced in Draft 4. As a simple workaround, we can use `properties` instead.